### PR TITLE
Attempt to make Blockhole blocking on L7

### DIFF
--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -63,8 +63,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()
 
-	t.Logf("Wait 20s for any open connections to expire")
-	time.Sleep(20 * time.Second)
+	t.Logf("Wait 5s for any open connections to expire")
+	time.Sleep(5 * time.Second)
 
 	t.Logf("Wait for new leader election with remaining members")
 	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
@@ -83,6 +83,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	proxy.UnblackholeRx()
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
+	time.Sleep(5 * time.Second)
 	assertRevision(t, leaderEPC, 21)
 	assertRevision(t, partitionedMember, 21)
 }

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -43,6 +43,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 		e2e.WithClusterSize(clusterSize),
 		e2e.WithSnapshotCount(10),
 		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithSSLTerminationProxy(true),
 		e2e.WithIsPeerTLS(true),
 		e2e.WithPeerProxy(true),
 	)
@@ -68,6 +69,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 
 	t.Logf("Wait for new leader election with remaining members")
 	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
+
 	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot.)")
 	writeKVs(t, leaderEPC.Etcdctl(), 0, 20)
 	e2e.AssertProcessLogs(t, leaderEPC, "saved snapshot")
@@ -76,7 +78,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	assertRevision(t, leaderEPC, 21)
 	assertRevision(t, partitionedMember, 1)
 
-	// Wait for some time to restore the network
+	// Wait for 1s before restoring the network
+	t.Logf("Wait 1s before restoring the network")
 	time.Sleep(1 * time.Second)
 	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
 	proxy.UnblackholeTx()

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestBlackholeByMockingPartitionLeader(t *testing.T) {
+	blackholeTestByMockingPartition(t, 3, true)
+}
+
+func TestBlackholeByMockingPartitionFollower(t *testing.T) {
+	blackholeTestByMockingPartition(t, 3, false)
+}
+
+func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLeader bool) {
+	e2e.BeforeTest(t)
+
+	t.Logf("Create an etcd cluster with %d member\n", clusterSize)
+	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t,
+		e2e.WithClusterSize(clusterSize),
+		e2e.WithSnapshotCount(10),
+		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithIsPeerTLS(true),
+		e2e.WithPeerProxy(true),
+	)
+	require.NoError(t, err, "failed to start etcd cluster: %v", err)
+	defer func() {
+		require.NoError(t, epc.Close(), "failed to close etcd cluster")
+	}()
+
+	leaderId := epc.WaitLeader(t)
+	mockPartitionNodeIndex := leaderId
+	if !partitionLeader {
+		mockPartitionNodeIndex = (leaderId + 1) % (clusterSize)
+	}
+	partitionedMember := epc.Procs[mockPartitionNodeIndex]
+	// Mock partition
+	proxy := partitionedMember.PeerProxy()
+	t.Logf("Blackholing traffic from and to member %q", partitionedMember.Config().Name)
+	proxy.BlackholeTx()
+	proxy.BlackholeRx()
+
+	t.Logf("Wait 20s for any open connections to expire")
+	time.Sleep(20 * time.Second)
+
+	t.Logf("Wait for new leader election with remaining members")
+	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
+	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot.)")
+	writeKVs(t, leaderEPC.Etcdctl(), 0, 20)
+	e2e.AssertProcessLogs(t, leaderEPC, "saved snapshot")
+
+	t.Log("Verifying the partitionedMember is missing new writes")
+	assertRevision(t, leaderEPC, 21)
+	assertRevision(t, partitionedMember, 1)
+
+	// Wait for some time to restore the network
+	time.Sleep(1 * time.Second)
+	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
+	proxy.UnblackholeTx()
+	proxy.UnblackholeRx()
+
+	leaderEPC = epc.Procs[epc.WaitLeader(t)]
+	assertRevision(t, leaderEPC, 21)
+	assertRevision(t, partitionedMember, 21)
+}
+
+func waitLeader(t testing.TB, epc *e2e.EtcdProcessCluster, excludeNode int) int {
+	var membs []e2e.EtcdProcess
+	for i := 0; i < len(epc.Procs); i++ {
+		if i == excludeNode {
+			continue
+		}
+		membs = append(membs, epc.Procs[i])
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return epc.WaitMembersForLeader(ctx, t, membs)
+}
+
+func assertRevision(t testing.TB, member e2e.EtcdProcess, expectedRevision int64) {
+	responses, err := member.Etcdctl().Status(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, expectedRevision, responses[0].Header.Revision, "revision mismatch")
+}

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -69,12 +69,13 @@ type LogsExpect interface {
 }
 
 type EtcdServerProcess struct {
-	cfg        *EtcdServerProcessConfig
-	proc       *expect.ExpectProcess
-	proxy      proxy.Server
-	lazyfs     *LazyFS
-	failpoints *BinaryFailpoints
-	donec      chan struct{} // closed when Interact() terminates
+	cfg                 *EtcdServerProcessConfig
+	proc                *expect.ExpectProcess
+	proxy               proxy.Server
+	SSLTerminationProxy proxy.Server
+	lazyfs              *LazyFS
+	failpoints          *BinaryFailpoints
+	donec               chan struct{} // closed when Interact() terminates
 }
 
 type EtcdServerProcessConfig struct {
@@ -91,6 +92,7 @@ type EtcdServerProcessConfig struct {
 	Name string
 
 	PeerURL       url.URL
+	PeerListenURL url.URL
 	ClientURL     string
 	ClientHTTPURL string
 	MetricsURL    string
@@ -100,8 +102,9 @@ type EtcdServerProcessConfig struct {
 	GoFailPort          int
 	GoFailClientTimeout time.Duration
 
-	LazyFSEnabled bool
-	Proxy         *proxy.ServerConfig
+	LazyFSEnabled       bool
+	Proxy               *proxy.ServerConfig
+	SSLTerminationProxy *proxy.ServerConfig
 }
 
 func NewEtcdServerProcess(t testing.TB, cfg *EtcdServerProcessConfig) (*EtcdServerProcess, error) {
@@ -150,6 +153,15 @@ func (ep *EtcdServerProcess) Start(ctx context.Context) error {
 	ep.donec = make(chan struct{})
 	if ep.proc != nil {
 		panic("already started")
+	}
+	if ep.cfg.SSLTerminationProxy != nil && ep.SSLTerminationProxy == nil {
+		ep.cfg.lg.Info("starting SSL termination proxy...", zap.String("name", ep.cfg.Name), zap.String("from", ep.cfg.SSLTerminationProxy.From.String()), zap.String("to", ep.cfg.SSLTerminationProxy.To.String()))
+		ep.SSLTerminationProxy = proxy.NewServer(*ep.cfg.SSLTerminationProxy)
+		select {
+		case <-ep.SSLTerminationProxy.Ready():
+		case err := <-ep.SSLTerminationProxy.Error():
+			return err
+		}
 	}
 	if ep.cfg.Proxy != nil && ep.proxy == nil {
 		ep.cfg.lg.Info("starting proxy...", zap.String("name", ep.cfg.Name), zap.String("from", ep.cfg.Proxy.From.String()), zap.String("to", ep.cfg.Proxy.To.String()))
@@ -200,23 +212,12 @@ func (ep *EtcdServerProcess) Stop() (err error) {
 
 	ep.cfg.lg.Info("stopping server...", zap.String("name", ep.cfg.Name))
 
-	defer func() {
-		ep.proc = nil
-	}()
-
-	err = ep.proc.Stop()
-	if err != nil {
-		return err
-	}
-	err = ep.proc.Close()
-	if err != nil && !strings.Contains(err.Error(), "unexpected exit code") {
-		return err
-	}
-	<-ep.donec
-	ep.donec = make(chan struct{})
-	if ep.cfg.PeerURL.Scheme == "unix" || ep.cfg.PeerURL.Scheme == "unixs" {
-		err = os.Remove(ep.cfg.PeerURL.Host + ep.cfg.PeerURL.Path)
-		if err != nil && !os.IsNotExist(err) {
+	// TODO: if we terminate the proxies first, stopping SSL termination proxy will not hang as long. Why?! (timeout setting?)
+	if ep.SSLTerminationProxy != nil {
+		ep.cfg.lg.Info("stopping SSL termination proxy...", zap.String("name", ep.cfg.Name))
+		err = ep.SSLTerminationProxy.Close()
+		ep.SSLTerminationProxy = nil
+		if err != nil {
 			return err
 		}
 	}
@@ -237,6 +238,28 @@ func (ep *EtcdServerProcess) Stop() (err error) {
 			return err
 		}
 	}
+
+	defer func() {
+		ep.proc = nil
+	}()
+
+	err = ep.proc.Stop()
+	if err != nil {
+		return err
+	}
+	err = ep.proc.Close()
+	if err != nil && !strings.Contains(err.Error(), "unexpected exit code") {
+		return err
+	}
+	<-ep.donec
+	ep.donec = make(chan struct{})
+	if ep.cfg.PeerURL.Scheme == "unix" || ep.cfg.PeerURL.Scheme == "unixs" {
+		err = os.Remove(ep.cfg.PeerURL.Host + ep.cfg.PeerURL.Path)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -375,7 +398,11 @@ func (f *BinaryFailpoints) SetupHTTP(ctx context.Context, failpoint, payload str
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("bad status code: %d", resp.StatusCode)
+		errorBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("bad status code: %d (%#v)", resp.StatusCode, string(errorBody))
 	}
 	return nil
 }

--- a/tests/robustness/failpoint/network.go
+++ b/tests/robustness/failpoint/network.go
@@ -64,9 +64,6 @@ func (tb triggerBlackhole) Available(config e2e.EtcdProcessClusterConfig, proces
 func Blackhole(ctx context.Context, t *testing.T, member e2e.EtcdProcess, clus *e2e.EtcdProcessCluster, shouldWaitTillSnapshot bool) error {
 	proxy := member.PeerProxy()
 
-	// Blackholing will cause peers to not be able to use streamWriters registered with member
-	// but peer traffic is still possible because member has 'pipeline' with peers
-	// TODO: find a way to stop all traffic
 	t.Logf("Blackholing traffic from and to member %q", member.Config().Name)
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()


### PR DESCRIPTION
Attempt to make Blockhole blocking on L7

Based on Fu Wei's idea [2], we employ blocking on L7 but without using
external tools.

The main idea is to read out `X-PeerURLs` from the header, since this
is how peer traffic identifies itself to others. As we also know that
all nodes will create direct connections with their peers, so the traffic
blocking will actually happen at all nodes' proxies (contrary to the
current design, where only the proxy of the peer is being blackholed.

However, this way of blocking (by `X-PeerURLs` from the header) will
miss certain types of traffic to certain endpoints,
e.g. /members, /version, and /raft/probing.

See below for the log extract,
as its header doesn't contain X-PeerURLs information.
- map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] /members
- map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] /version
- map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] /raft/probing

In order to read out `X-PeerURLs` from the header, we need to terminate
the SSL connection, as we can't drop cleartext traffic (ref [1]). Thus,
a new option `e2e.WithSSLTerminationProxy(true)` is introduced, which
will change the network flow into
```
A -- B's SSL termination proxy - B's transparent proxy - B
     ^ newly introduced          ^ in the original codebase
```
This prototype doesn't address
- blocking only RX or TX traffic
- slowness when performing test cleanup
, and the coding convention needs to be improved as it's still a PoC

References:
[1] https://github.com/etcd-io/etcd/issues/15595
[2] https://github.com/etcd-io/etcd/issues/17737